### PR TITLE
Check file MD5 before replacing database

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,12 @@ cravler_max_mind_geo_ip:
 ## Download and update the MaxMind GeoIp2 database
 
 ``` bash
-app/console cravler:maxmind:geoip-update
+php app/console cravler:maxmind:geoip-update
+```
+
+You can use the *--no-md5-check* option if you want to skip MD5 check.
+``` bash
+php app/console cravler:maxmind:geoip-update --no-md5-check
 ```
 
 ## How to use


### PR DESCRIPTION
- Added basic MD5 checking, with the ability to disable it.
- Safer update (decompress in sys_get_tmp_dir(), checks md5, then moves the file)
- Console outputs modified

It is possible to avoid md5 checking by adding _--no-md5-check_ on the command line.
