### PR TITLE
DI improvements

### DIFF
--- a/DependencyInjection/CravlerMaxMindGeoIpExtension.php
+++ b/DependencyInjection/CravlerMaxMindGeoIpExtension.php
@@ -23,10 +23,11 @@ class CravlerMaxMindGeoIpExtension extends Extension
     {
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
-
-        $container->setParameter(self::CONFIG_KEY, $config);
+        $container->setParameter(self::CONFIG_KEY, $config); // BC
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+
+        $container->findDefinition('cravler_max_mind_geo_ip.service.geo_ip_service')->setArguments(array($config));
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" ?>
 
 <container xmlns="http://symfony.com/schema/dic/services"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
         <service id="cravler_max_mind_geo_ip.service.geo_ip_service"
                  class="Cravler\MaxMindGeoIpBundle\Service\GeoIpService">
-            <argument type="service" id="service_container" />
         </service>
     </services>
 

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
 
     <services>
         <service id="cravler_max_mind_geo_ip.service.geo_ip_service"
+                 public="true"
                  class="Cravler\MaxMindGeoIpBundle\Service\GeoIpService">
         </service>
     </services>

--- a/Service/GeoIpService.php
+++ b/Service/GeoIpService.php
@@ -25,11 +25,12 @@ class GeoIpService
     private $config = array();
 
     /**
-     * @param ContainerInterface $container
+     * GeoIpService constructor.
+     * @param array $config
      */
-    public function __construct(ContainerInterface $container)
+    public function __construct(array $config)
     {
-        $this->config = $container->getParameter(CravlerMaxMindGeoIpExtension::CONFIG_KEY);
+        $this->config = $config;
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.3|~3.0|~4.0",
         "geoip2/geoip2": "~2.0"
     },
     "autoload": {


### PR DESCRIPTION
Hello there,

To avoid having to compile a container or boot a kernel when using the service in a test suite, I removed the dependency on ContainerInterface in GeoIPService constructor.
Now just an array of config values need to be injected - this is now done via the bundle's extension.

I also added SF 4.0+ to allow installing this bundle on Symfony 4.