### PR TITLE
Enable autowiring

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,8 @@
                  public="true"
                  class="Cravler\MaxMindGeoIpBundle\Service\GeoIpService">
         </service>
+               
+        <service id="Cravler\MaxMindGeoIpBundle\Service\GeoIpService" alias="cravler_max_mind_geo_ip.service.geo_ip_service" />
     </services>
 
 </container>


### PR DESCRIPTION
This tiny PR enables `Cravler\MaxMindGeoIpBundle\Service\GeoIpService` to be autowired in SF 3.3+ / SF4+ applications. No BC break expected.

Related to #9